### PR TITLE
https support

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,4 +1,5 @@
 var http = require('http');
+var https = require('https');
 var connect = require('connect');
 var serveStatic = require('serve-static');
 var extend = require('xtend');
@@ -41,7 +42,13 @@ function createSpaServer (options) {
   addMiddleware('fallback', getFallbackHandler());
   addMiddleware('$end');
 
-  var server = http.createServer(connectInstance);
+  var server;
+  if (options.credentials) {
+    server = https.createServer(options.credentials, connectInstance);
+  }
+  else {
+    server = http.createServer(connectInstance);
+  }
 
   handleErrors();
 


### PR DESCRIPTION
I hacked this.
If one sends the option credentials with something like:

``` javascript
var fs = require('fs');
var credentials = {
  key  : fs.readFileSync('cert/server.key'),
  cert : fs.readFileSync('cert/server.crt')
};

var server = serverFactory.create({
  credentials: credentials,
  (...)
```

`spa-server` spawns an https server instead.
